### PR TITLE
Add link to choo-location-electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ under the hood:
 
 - [Freenode](https://webchat.freenode.net/?channels=choo)
 
+### Electron
+
+- [choo-location-electron](https://github.com/bcomnes/choo-location-electron) - fix choo's router in electron
+
 ### Resources
 > :movie_camera: : videos
 > :computer: : tutorials


### PR DESCRIPTION
Choo's router does't work out of the box with electron.  This module fixes that.
